### PR TITLE
Simplify the docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ There are two ways to run the application:
     docker compose -f docker-compose.yml up --build -d
   ```
   ```bash
-    docker exec -it pomotracker-app-1 python manage.py migrate   
+    docker compose exec app python manage.py migrate
   ```
   ```bash
-    docker exec -it pomotracker-postgres-1 ./home/postgres/bypass_socialaccount_settings.sh
+    docker compose exec  -T postgres psql -U postgres -d pomotracker < config/postgres/bypass_socialaccount_settings.sql
   ```
 
 2. **Using a Virtual Environment (Pipenv or Virtualenv):**

--- a/config/postgres/Dockerfile
+++ b/config/postgres/Dockerfile
@@ -1,5 +1,0 @@
-FROM postgres:15-alpine
-
-# Copy the custom script
-COPY bypass_socialaccount_settings.sh /home/postgres/
-

--- a/config/postgres/bypass_socialaccount_settings.sql
+++ b/config/postgres/bypass_socialaccount_settings.sql
@@ -1,19 +1,5 @@
-#!/bin/bash
-
-DB_NAME="pomotracker"
-DB_USER="postgres"
-
-
-SQL_COMMANDS="
 INSERT INTO socialaccount_socialapp (id, provider, name, client_id, secret, settings, key, provider_id)
 VALUES (2, 'google', 'google', 1, 123, '{}', 1, 1);
 
 INSERT INTO socialaccount_socialapp_sites (id, site_id, socialapp_id)
 VALUES (1, 2, 2);
-"
-
-# echo "$SQL_COMMANDS" | psql -U $DB_USER -d $DB_NAME
-psql -U $DB_USER -d $DB_NAME -c "$SQL_COMMANDS"
-
-echo "SQL commands executed successfully."
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - pomotracker-network
 
   postgres:
-    build: ./config/postgres
+    image: postgres:15-alpine
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=devpostgres1234


### PR DESCRIPTION
Simplify by not having a Dockerfile for postgres and instead pipe in the sql for setting up the socialaccount settings.
Though, putting them into a migration might be even better.