### PR TITLE
Simplify the docker container for nginx

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,7 +1,7 @@
 server_tokens               off;
 
 upstream pomotracker {
-    server localhost:80;
+    server app:80;
 }
 
 server {

--- a/config/nginx/Dockerfile
+++ b/config/nginx/Dockerfile
@@ -1,4 +1,0 @@
-FROM nginx:stable-alpine-slim
-
-RUN rm /etc/nginx/conf.d/default.conf
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,11 +37,12 @@ services:
       - postgres
 
   nginx:
-    build: ./config/nginx
+    image: nginx:stable-alpine-slim
     ports:
       - "1337:80"
     volumes:
       - static_volume:/home/app/pomotracker/staticfiles
+      - ./config/nginx.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - app
     networks:


### PR DESCRIPTION
Safes you from the hassle of an extra container for nginx.
I didn't change the docker-compose.prod.yml file.