### PR TITLE
Add offset to chart squares to account for weekdays before January 1st

### DIFF
--- a/app/static/app/css/charts.css
+++ b/app/static/app/css/charts.css
@@ -147,6 +147,9 @@ body.coral {
   border: 1px solid var(--text-color);
 }
 
+.squares li:not([data-date]) {
+  visibility: hidden;
+}
 .squares li[data-level="1"] {
   background-color: var(--level-1);
 }

--- a/app/static/app/js/charts_index.js
+++ b/app/static/app/js/charts_index.js
@@ -39,6 +39,12 @@ function createSquares(year) {
     while (squares.firstChild) {
       squares.removeChild(squares.firstChild);
     }
+    // add empty cells for each day before January 1st
+    const days_from_previous_year = (new Date(currentYear, 0, 1)).getDay();
+    for (let i = 0; i < days_from_previous_year; i++) {
+      squares.insertAdjacentHTML('beforeend', '<li data-level="0"></li>');
+    }
+
     for (let i = 0; i < keys.length; i++) {
       const month = keys[i];
       for (let day = 1; day <= month.days; day++) {
@@ -57,6 +63,7 @@ function createSquares(year) {
         square.addEventListener('mouseover', () => {
           const date = square.getAttribute('data-date');
           const count = square.getAttribute('data-count');
+          if (!date) { tag_squares.innerHTML = ''; return };
           if (count > 0) {
             tag_squares.innerHTML = `${count} pomodoros on ${date}, ${year}`;
           } else {


### PR DESCRIPTION
I noticed there were empty fields missing as the year did not start on a Sunday. I'd love to have it start on a Monday optionally, but [Firefox lacks the `getWeekInfo`  method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo) but this [polyfill does](https://www.npmjs.com/package/@bart-krakowski/get-week-info-polyfill).