### PR TITLE
comment out ranks

### DIFF
--- a/app/static/app/js/leaderboard.js
+++ b/app/static/app/js/leaderboard.js
@@ -98,14 +98,14 @@ function displayItemDelay(user, delay, selectedPeriod, data) {
         rewardsContainer.appendChild(bronzeSpan);
       }
 
-      const rankContainer = document.createElement('div');
-      rankContainer.classList.add('rank-container');
-      const rankSpan = document.createElement('span');
-      rankSpan.textContent = `#${rewards.rank}`;
-      rankSpan.title = 'PomoTracker Rank';
-      rankContainer.appendChild(rankSpan);
+      // const rankContainer = document.createElement('div');
+      // rankContainer.classList.add('rank-container');
+      // const rankSpan = document.createElement('span');
+      // rankSpan.textContent = `#${rewards.rank}`;
+      // rankSpan.title = 'PomoTracker Rank';
+      // rankContainer.appendChild(rankSpan);
 
-      leftContainer.appendChild(rankContainer);
+      // leftContainer.appendChild(rankContainer);
       leftContainer.appendChild(rewardsContainer);
       userLeaderboard.appendChild(leftContainer);
 

--- a/app/templates/app/profile.html
+++ b/app/templates/app/profile.html
@@ -39,8 +39,10 @@
                 {% endif %}
             </div>
             <div class="right">
+            {#
                 <p title="Average Rank, i.e: (month's position / number of months) " id="first"><span>&#128310;</span>
                     {{userProfile.rewards.getAverageRank }}</p>
+            #}
                 <p title="Average Pomodoros per day"><span>&#128310;</span>{{ averagePomos }}</p>
             </div>
         </div>


### PR DESCRIPTION
This pull request makes minor UI changes related to how user rank information is displayed in the leaderboard and user profile. Specifically, it comments out the display of user rank in both the leaderboard and the profile page, likely to hide this information from users for now.

Leaderboard UI changes:
* Commented out the code that creates and displays the user's rank (`rewards.rank`) in the leaderboard item, so rank is no longer shown on the leaderboard.

Profile page UI changes:
* Commented out the HTML block that displayed the user's average rank in the profile page, hiding this metric from the user interface.