### PR TITLE
Update pipeline to delete stale Docker volumes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,8 @@ stages:
               sshEndpoint: '$(SSH_SERVICE_CONNECTION)'
               runOptions: 'commands'
               commands: |
-                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml down &>/dev/null ; echo $?
+                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml down
                 bash ~/pomotracker/rm_img_docker.sh viodid/pomotracker latest pomotracker.app
-                bash ~/pomotracker/rm_img_docker.sh viodid/pomotracker-nginx latest pomotracker.app
-                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml up -d &>/dev/null ; echo $?
+                docker volume prune -f
+                docker volume rm pomotracker_build_files_static_volume
+                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml up -d


### PR DESCRIPTION
This pull request updates the deployment stage in the `azure-pipelines.yml` file to improve Docker resource management and simplify command output. The changes focus on cleaning up unused Docker volumes before starting the application and removing unnecessary command output redirection.

**Deployment process improvements:**

* Removed output redirection (`&>/dev/null ; echo $?`) from the `docker compose down` and `docker compose up` commands to provide clearer command output during deployment.
* Added explicit cleanup of Docker volumes by running `docker volume prune -f` and removing the `pomotracker_build_files_static_volume` before starting the application, ensuring a cleaner deployment environment.
* Removed the command to delete the `viodid/pomotracker-nginx` image, likely because it is no longer needed in the deployment process.