### PR TITLE
update Docker pipeline for output suppression

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,8 @@ stages:
               sshEndpoint: '$(SSH_SERVICE_CONNECTION)'
               runOptions: 'commands'
               commands: |
-                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml down
+                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml down &>/dev/null ; echo $?
                 bash ~/pomotracker/rm_img_docker.sh viodid/pomotracker latest pomotracker.app
                 docker volume prune -f
                 docker volume rm pomotracker_build_files_static_volume
-                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml up -d
+                docker compose -f ~/pomotracker/pomotracker_build_files/docker-compose.prod.yml up -d &>/dev/null ; echo $?


### PR DESCRIPTION
This pull request makes minor adjustments to the deployment commands in the `azure-pipelines.yml` to prevent pipeline from failing

- Deployment process:
  * The `docker compose down` and `docker compose up -d` commands now suppress their standard output and error by redirecting them to `/dev/null`, and explicitly print their exit status using `echo $?`.