### PR TITLE
UI improvements: filters, profile layout, pie chart, mock data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,12 +15,19 @@ docker compose exec app python manage.py migrate
 # Access at http://localhost:1337
 ```
 
+**Important:** When restarting Docker services, always remove the static files volumes so that changes are loaded:
+```bash
+docker compose down -v && docker compose up --build -d
+```
+
 ### Django management
 ```bash
 python manage.py runserver 0.0.0.0:1337    # local dev server (needs local PG + Redis)
 python manage.py migrate                    # apply migrations
 python manage.py makemigrations             # generate migrations after model changes
 python manage.py giveRewards                # custom command: monthly leaderboard rewards
+python manage.py createMockData              # create 3 mock users with ~150-300 pomodoros each
+python manage.py createMockData --max-pomos 500  # adjust max pomodoros per user
 ```
 
 ### Environment

--- a/app/management/commands/createMockData.py
+++ b/app/management/commands/createMockData.py
@@ -1,0 +1,62 @@
+import random
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+from django.utils import timezone
+
+from app.models import Pomodoro, Tag, UserSettings, Rewards
+
+
+MOCK_USERS = [
+    {"username": "alice_dev", "tags": ["coding", "review", "design", "reading"]},
+    {"username": "bob_learns", "tags": ["study", "math", "writing", "exercise"]},
+    {"username": "carol_work", "tags": ["meetings", "planning", "deep-work", "emails"]},
+]
+
+
+class Command(BaseCommand):
+    help = "Create mock users with random pomodoros for development."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--max-pomos",
+            type=int,
+            default=300,
+            help="Maximum pomodoros per user (default: 300)",
+        )
+
+    def handle(self, *args, **options):
+        max_pomos = options["max_pomos"]
+        now = timezone.now()
+
+        for mock in MOCK_USERS:
+            username = mock["username"]
+            if User.objects.filter(username=username).exists():
+                self.stdout.write(f"User '{username}' already exists, skipping.")
+                continue
+
+            user = User.objects.create_user(username=username, password="testpass123!")
+            UserSettings.objects.create(user=user)
+            Rewards.objects.create(user=user)
+
+            tags = []
+            for tag_name in mock["tags"]:
+                tag, _ = Tag.objects.get_or_create(tag=tag_name)
+                tags.append(tag)
+
+            num_pomos = random.randint(max_pomos // 2, max_pomos)
+            pomodoros = []
+            for _ in range(num_pomos):
+                days_ago = random.randint(0, 365)
+                hour = random.randint(6, 23)
+                minute = random.randint(0, 59)
+                dt = now - timedelta(days=days_ago, hours=hour, minutes=minute)
+                pomodoros.append(
+                    Pomodoro(user=user, tag=random.choice(tags), datetime=dt)
+                )
+
+            Pomodoro.objects.bulk_create(pomodoros)
+            self.stdout.write(f"Created '{username}' with {num_pomos} pomodoros.")
+
+        self.stdout.write(self.style.SUCCESS("Done!"))

--- a/app/static/app/css/styles.css
+++ b/app/static/app/css/styles.css
@@ -834,7 +834,7 @@ animation: prog 121s linear forwards, glow 1s 120s ease-in-out forwards;
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow);
   margin: 30px 0;
-  width: 47%;
+  width: 48%;
 }
 
 .settings-profile form {
@@ -985,10 +985,12 @@ animation: prog 121s linear forwards, glow 1s 120s ease-in-out forwards;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  align-items: flex-start;
 }
 
 #tags-settings {
   margin: 30px 0;
+  width: 48%;
 }
 
 /* Accounts styles */

--- a/app/static/app/js/charts.js
+++ b/app/static/app/js/charts.js
@@ -290,7 +290,7 @@ function aggregatedPomosByTagLocal(pomos) {
     const tag = pomos[i]['tag'];
     tagCounts[tag] = (tagCounts[tag] || 0) + 1;
   }
-  return aggregateToChart(tagCounts);
+  return aggregateToChart(tagCounts).sort((a, b) => b[1] - a[1]);
 }
 
 function fontColor() {

--- a/app/templates/app/pomodoros.html
+++ b/app/templates/app/pomodoros.html
@@ -12,17 +12,11 @@ Pomodoros
 
 {% block body %}
 <main>
-    <div class="period-filter">
-        <a href="?period=week" class="{% if current_period == 'week' %}active{% endif %}">Week</a>
-        <a href="?period=month" class="{% if current_period == 'month' %}active{% endif %}">Month</a>
-        <a href="?period=year" class="{% if current_period == 'year' %}active{% endif %}">Year</a>
-        <a href="?period=all" class="{% if current_period == 'all' %}active{% endif %}">All</a>
-    </div>
     <div class="pagination top">
         <span class="step-links">
             {% if page_obj.has_previous %}
-            <a href="?period={{ current_period }}&page=1">&laquo;</a>
-            <a href="?period={{ current_period }}&page={{ page_obj.previous_page_number }}">previous</a>
+            <a href="?page=1">&laquo;</a>
+            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
             {% endif %}
 
             <span class="current">
@@ -30,8 +24,8 @@ Pomodoros
             </span>
 
             {% if page_obj.has_next %}
-            <a href="?period={{ current_period }}&page={{ page_obj.next_page_number }}">next</a>
-            <a href="?period={{ current_period }}&page={{ page_obj.paginator.num_pages }}">&raquo;</a>
+            <a href="?page={{ page_obj.next_page_number }}">next</a>
+            <a href="?page={{ page_obj.paginator.num_pages }}">&raquo;</a>
             {% endif %}
         </span>
     </div>
@@ -85,8 +79,8 @@ Pomodoros
     <div class="pagination bottom">
         <span class="step-links">
             {% if page_obj.has_previous %}
-            <a href="?period={{ current_period }}&page=1">&laquo;</a>
-            <a href="?period={{ current_period }}&page={{ page_obj.previous_page_number }}">previous</a>
+            <a href="?page=1">&laquo;</a>
+            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
             {% endif %}
 
             <span class="current">
@@ -94,8 +88,8 @@ Pomodoros
             </span>
 
             {% if page_obj.has_next %}
-            <a href="?period={{ current_period }}&page={{ page_obj.next_page_number }}">next</a>
-            <a href="?period={{ current_period }}&page={{ page_obj.paginator.num_pages }}">&raquo;</a>
+            <a href="?page={{ page_obj.next_page_number }}">next</a>
+            <a href="?page={{ page_obj.paginator.num_pages }}">&raquo;</a>
             {% endif %}
         </span>
     </div>

--- a/app/templates/app/profile.html
+++ b/app/templates/app/profile.html
@@ -47,12 +47,6 @@
             </div>
         </div>
         {% if display %}
-        <div class="period-filter">
-            <a href="?period=week" class="{% if current_period == 'week' %}active{% endif %}">Week</a>
-            <a href="?period=month" class="{% if current_period == 'month' %}active{% endif %}">Month</a>
-            <a href="?period=year" class="{% if current_period == 'year' %}active{% endif %}">Year</a>
-            <a href="?period=all" class="{% if current_period == 'all' %}active{% endif %}">All</a>
-        </div>
         <div class="profile-container">
             <div class="settings-profile">
                 <h2>{{ userProfile.username | title }} Settings</h2>
@@ -168,13 +162,13 @@
         </div>
         <span class="step-links">
             {% if page_obj.has_previous %}
-            <a href="?period={{ current_period }}&page=1">&laquo;</a>
-            <a href="?period={{ current_period }}&page={{ page_obj.previous_page_number }}">previous</a>
+            <a href="?page=1">&laquo;</a>
+            <a href="?page={{ page_obj.previous_page_number }}">previous</a>
             {% endif %}
             <span class="current">| Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }} |</span>
             {% if page_obj.has_next %}
-            <a href="?period={{ current_period }}&page={{ page_obj.next_page_number }}">next</a>
-            <a href="?period={{ current_period }}&page={{ page_obj.paginator.num_pages }}">&raquo;</a>
+            <a href="?page={{ page_obj.next_page_number }}">next</a>
+            <a href="?page={{ page_obj.paginator.num_pages }}">&raquo;</a>
             {% endif %}
         </span>
         {% else %}

--- a/app/views.py
+++ b/app/views.py
@@ -1,4 +1,5 @@
 """Views for the app."""
+
 import secrets
 from django.core.paginator import Paginator
 from django.contrib.auth import logout
@@ -7,10 +8,16 @@ from django.http import HttpResponseRedirect, HttpResponseNotFound
 from django.shortcuts import render
 from django.urls import reverse
 
-from .models import User, SlicePomodoros, UserSettings, Rewards, Statistics, get_period_start
+from .models import (
+    User,
+    SlicePomodoros,
+    UserSettings,
+    Rewards,
+    Statistics,
+    get_period_start,
+)
 from .forms import ProfileForm
 from . import helpers
-
 
 
 def index(request):
@@ -22,10 +29,8 @@ def index(request):
         generateRewards(request)
         user = User.objects.get(username=request.user.username)
         pomodoros = SlicePomodoros(user.pomodoros, user)
-        return render(request, 'app/index.html', {
-            'pomodoros': pomodoros
-        })
-    return render(request, 'app/index.html')
+        return render(request, "app/index.html", {"pomodoros": pomodoros})
+    return render(request, "app/index.html")
 
 
 def profile(request, username):
@@ -33,66 +38,94 @@ def profile(request, username):
     if request.user.is_authenticated:
         user = User.objects.get(username=request.user.username)
         if username == request.user.username:
-            period = request.GET.get('period', 'all')
+            period = request.GET.get("period", "all")
             period_start = get_period_start(period)
             user_pomodoros = user.pomodoros.all()
             if period_start:
                 user_pomodoros = user_pomodoros.filter(datetime__gte=period_start)
-            tags = tuple(Statistics.aggregatePomodorosByTag(user, pomodoros=user_pomodoros).items())
-            paginator = Paginator(tags, 13)
-            page_number = request.GET.get('page')
+            tags = tuple(
+                Statistics.aggregatePomodorosByTag(
+                    user, pomodoros=user_pomodoros
+                ).items()
+            )
+            paginator = Paginator(tags, 22)
+            page_number = request.GET.get("page")
             page_obj = paginator.get_page(page_number)
-            form = ProfileForm(initial={
-                'shortBreak': user.settings.shortBreak,
-                'longBreak': user.settings.longBreak,
-                'theme': user.settings.theme,
-                'startSound': user.settings.startSound,
-                'stopSound': user.settings.stopSound,
-                'timezone': user.settings.timezone,
-            })
-            if request.method == 'POST':
-                form = ProfileForm(request.POST, request.FILES, initial={
-                    'shortBreak': user.settings.shortBreak,
-                    'longBreak': user.settings.longBreak,
-                    'theme': user.settings.theme,
-                    'startSound': user.settings.startSound,
-                    'stopSound': user.settings.stopSound,
-                    'timezone': user.settings.timezone,
-                })
+            form = ProfileForm(
+                initial={
+                    "shortBreak": user.settings.shortBreak,
+                    "longBreak": user.settings.longBreak,
+                    "theme": user.settings.theme,
+                    "startSound": user.settings.startSound,
+                    "stopSound": user.settings.stopSound,
+                    "timezone": user.settings.timezone,
+                }
+            )
+            if request.method == "POST":
+                form = ProfileForm(
+                    request.POST,
+                    request.FILES,
+                    initial={
+                        "shortBreak": user.settings.shortBreak,
+                        "longBreak": user.settings.longBreak,
+                        "theme": user.settings.theme,
+                        "startSound": user.settings.startSound,
+                        "stopSound": user.settings.stopSound,
+                        "timezone": user.settings.timezone,
+                    },
+                )
                 if form.is_valid():
                     helpers.saveSettings(form.cleaned_data, user)
                     return HttpResponseRedirect(reverse("index"))
                 else:
-                    return render(request, 'app/profile.html', {
-                        'message': 'Invalid form',
-                        'form': form,
-                        'display': True,
-                        'userProfile': user,
-                        'averagePomos': Statistics.getAveragePomodoros(user, pomodoros=user_pomodoros),
-                        'page_obj': page_obj,
-                        'current_period': period,
-                    })
-            return render(request, 'app/profile.html', {
-                'form': form,
-                'display': True,
-                'userProfile': user,
-                'averagePomos': Statistics.getAveragePomodoros(user, pomodoros=user_pomodoros),
-                'page_obj': page_obj,
-                'current_period': period,
-            })
+                    return render(
+                        request,
+                        "app/profile.html",
+                        {
+                            "message": "Invalid form",
+                            "form": form,
+                            "display": True,
+                            "userProfile": user,
+                            "averagePomos": Statistics.getAveragePomodoros(
+                                user, pomodoros=user_pomodoros
+                            ),
+                            "page_obj": page_obj,
+                            "current_period": period,
+                        },
+                    )
+            return render(
+                request,
+                "app/profile.html",
+                {
+                    "form": form,
+                    "display": True,
+                    "userProfile": user,
+                    "averagePomos": Statistics.getAveragePomodoros(
+                        user, pomodoros=user_pomodoros
+                    ),
+                    "page_obj": page_obj,
+                    "current_period": period,
+                },
+            )
 
     if User.objects.filter(username=username):
         userProfile = User.objects.get(username=username)
-        period = request.GET.get('period', 'all')
+        period = request.GET.get("period", "all")
         period_start = get_period_start(period)
         user_pomodoros = userProfile.pomodoros.all()
         if period_start:
             user_pomodoros = user_pomodoros.filter(datetime__gte=period_start)
-        return render(request, 'app/profile.html', {
-            'userProfile': userProfile,
-            'averagePomos': Statistics.getAveragePomodoros(userProfile, pomodoros=user_pomodoros),
-            'current_period': period,
-        })
+        return render(
+            request,
+            "app/profile.html",
+            {
+                "userProfile": userProfile,
+                "averagePomos": Statistics.getAveragePomodoros(
+                    userProfile, pomodoros=user_pomodoros
+                ),
+                "current_period": period,
+            },
+        )
     return HttpResponseNotFound(request)
 
 
@@ -100,39 +133,43 @@ def profile(request, username):
 def pomodorosList(request):
     """Display all pomodoros of the user"""
     user = User.objects.get(username=request.user.username)
-    period = request.GET.get('period', 'all')
-    pomodoros = user.pomodoros.all().order_by('-datetime')
+    period = request.GET.get("period", "all")
+    pomodoros = user.pomodoros.all().order_by("-datetime")
 
     period_start = get_period_start(period)
     if period_start:
         pomodoros = pomodoros.filter(datetime__gte=period_start)
 
     paginator = Paginator(pomodoros, 50)
-    pageNumber = request.GET.get('page')
+    pageNumber = request.GET.get("page")
     pageObj = paginator.get_page(pageNumber)
-    return render(request, 'app/pomodoros.html', {
-        'page_obj': pageObj,
-        'current_period': period,
-    })
+    return render(
+        request,
+        "app/pomodoros.html",
+        {
+            "page_obj": pageObj,
+            "current_period": period,
+        },
+    )
 
 
 def leaderboard(request):
     """Display the leaderboard page"""
-    return render(request, 'app/leaderboard.html')
+    return render(request, "app/leaderboard.html")
 
 
 @login_required
 def charts(request):
     """Display the charts page"""
-    return render(request, 'app/charts.html')
+    return render(request, "app/charts.html")
 
 
 def privacy(request):
-    return render(request, 'app/privacy.html')
+    return render(request, "app/privacy.html")
 
 
 def terms(request):
-    return render(request, 'app/terms.html')
+    return render(request, "app/terms.html")
 
 
 def logout_view(request):
@@ -141,7 +178,7 @@ def logout_view(request):
 
 
 def apiReference(request):
-    return render(request, 'app/api.html')
+    return render(request, "app/api.html")
 
 
 def token(request):
@@ -150,12 +187,8 @@ def token(request):
         if user.settings.token is None:
             user.settings.token = secrets.token_urlsafe(16)
             user.settings.save()
-        return render(request, 'app/token.html', {
-            'message': user.settings.token
-        })
-    return render(request, 'app/token.html', {
-        'message': 'You need to be logged in.'
-    })
+        return render(request, "app/token.html", {"message": user.settings.token})
+    return render(request, "app/token.html", {"message": "You need to be logged in."})
 
 
 def generateToken(request):
@@ -170,18 +203,18 @@ def generateToken(request):
 def generateColors(request):
     user = User.objects.get(username=request.user.username)
     if not user.settings.breakColor:
-        user.settings.color = '#ADFF2F'
+        user.settings.color = "#ADFF2F"
     if not user.settings.focusColor:
-        user.settings.focusColor = '#F1C232'
+        user.settings.focusColor = "#F1C232"
     user.settings.save()
 
 
 def generateSoundsAndTime(request):
     user = User.objects.get(username=request.user.username)
     if not user.settings.startSound:
-        user.settings.startSound = '#ding'
+        user.settings.startSound = "#ding"
     if not user.settings.stopSound:
-        user.settings.stopSound = '#whoosh'
+        user.settings.stopSound = "#whoosh"
     if not user.settings.longBreak:
         user.settings.longBreak = 15
     user.settings.save()
@@ -211,3 +244,4 @@ def generateRewards(request):
             Rewards(user=user).save()
         return user.rewards
     return None
+


### PR DESCRIPTION
## Summary
- Remove period filter buttons from `/pomodoros` and profile settings pages (keep only on `/charts` and profile charts)
- Align profile settings and tags table to equal width (48% each) with top alignment
- Increase tags pagination from 13 to 22 per page to better fill available space
- Sort pie chart slices by count descending for readability
- Add `createMockData` management command for development
- Update CLAUDE.md with new command and Docker volume cleanup guideline

## Test plan
- [x] Visit `/pomodoros` — no period filter row, pagination works
- [x] Visit own profile — no period filter, settings and tags table aligned at equal width
- [x] Visit another user's profile — chart period filter still present
- [x] Visit `/charts` — period filter present, pie chart sorted largest to smallest
- [x] Visit `/leaderboard` — radio buttons unchanged
- [x] Run `python manage.py createMockData` — creates mock users with pomodoros

🤖 Generated with [Claude Code](https://claude.com/claude-code)