### PR TITLE
Refactor pie chart export and adjust margin threshold

### DIFF
--- a/app/static/app/js/charts.js
+++ b/app/static/app/js/charts.js
@@ -200,7 +200,7 @@ function drawPieChart1() {
         right: 40,
       },
       is3D: true,
-      sliceVisibilityThreshold: 0.01,
+      sliceVisibilityThreshold: 0.001,
       pieSliceText: 'label',
       tooltip: {
         showColorCode: true,

--- a/app/views.py
+++ b/app/views.py
@@ -209,11 +209,11 @@ def export_csv(request):
 
     writer = csv.writer(response)
     writer.writerow(["id", "date", "time", "tag"])
-    for pomo in pomodoros:
+    for idx, pomo in enumerate(pomodoros):
         local_dt = timezone.localtime(pomo.datetime)
         writer.writerow(
             [
-                pomo.id,
+                idx,
                 local_dt.strftime("%Y-%m-%d"),
                 local_dt.strftime("%H:%M:%S"),
                 pomo.tag.tag,


### PR DESCRIPTION
This pull request introduces a minor adjustment to the pie chart rendering and a change to the CSV export functionality. The most notable updates are a tweak to the pie chart's slice visibility and a modification to how IDs are represented in exported CSV files.

Visualization improvements:
* Reduced the `sliceVisibilityThreshold` in the `drawPieChart1` function in `charts.js` to 0.001, allowing smaller slices to be visible in the pie chart.

CSV export changes:
* Updated the `export_csv` function in `views.py` to use the row index instead of the database `id` as the identifier in exported CSV files.